### PR TITLE
Allow username/email for /auth username

### DIFF
--- a/simple-jwt-login/src/Services/AuthenticateService.php
+++ b/simple-jwt-login/src/Services/AuthenticateService.php
@@ -99,12 +99,24 @@ class AuthenticateService extends BaseService implements ServiceInterface
             );
         }
 
-        $user = isset($this->request['username'])
-            ? $this->wordPressData->getUserByUserLogin(
-                $this->wordPressData->sanitizeTextField($this->request['username'])
+        $auth_method = 'email';
+
+        if (isset($this->request['username'])) {
+            $user_by = $this->request['username'];
+            $auth_method = (str_contains($this->request['username'], '@'))
+            ? 'email'
+            : 'username';
+            }    
+        else {
+            $user_by = $this->request['email'];
+        }
+
+        $user = ($auth_method == 'email')
+            ? $this->wordPressData->getUserDetailsByEmail(
+                $this->wordPressData->sanitizeTextField($user_by)
             )
-            : $this->wordPressData->getUserDetailsByEmail(
-                $this->wordPressData->sanitizeTextField($this->request['email'])
+            : $this->wordPressData->getUserByUserLogin(
+                $this->wordPressData->sanitizeTextField($user_by)
             );
 
         if (empty($user)) {


### PR DESCRIPTION
Allow user to use either username or email in username field for /auth endpoint. This is inline with how a user normally logs in to WordPress


## Issue Link
#19

## Types of changes
- [ ] Bug fix
- [x] New feature

## Description
<!-- Please describe what you have changed or added -->
Added check for email/username in username field in AuthenticationService.php.

## How has this been tested?
Tested on dev server running WP 6.1.1 and PHP 8.1.

## Screenshots (optional)
<!-- Please provide some screenshots of your tests -->

## Checklist:
- [x] My code is tested.
- [ ] I wrote tests for the impacted area
- [ ] I ran `composer check-plugin` locally